### PR TITLE
[Feat] #6 - 커스텀 네비게이션바 구현

### DIFF
--- a/Diverology/Diverology/Resource/Assets.xcassets/Color/blue700.colorset/Contents.json
+++ b/Diverology/Diverology/Resource/Assets.xcassets/Color/blue700.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
-          "blue" : "0x00",
-          "green" : "0x00",
-          "red" : "0x00"
+          "alpha" : "1.000",
+          "blue" : "0xA8",
+          "green" : "0x86",
+          "red" : "0x56"
         }
       },
       "idiom" : "universal"

--- a/Diverology/Diverology/Resource/Assets.xcassets/Color/blue800.colorset/Contents.json
+++ b/Diverology/Diverology/Resource/Assets.xcassets/Color/blue800.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
-          "blue" : "0x00",
-          "green" : "0x00",
-          "red" : "0x00"
+          "alpha" : "1.000",
+          "blue" : "0x87",
+          "green" : "0x60",
+          "red" : "0x38"
         }
       },
       "idiom" : "universal"

--- a/Diverology/Diverology/Resource/Assets.xcassets/Color/blue900.colorset/Contents.json
+++ b/Diverology/Diverology/Resource/Assets.xcassets/Color/blue900.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.400",
-          "blue" : "0x00",
-          "green" : "0x00",
-          "red" : "0x00"
+          "alpha" : "1.000",
+          "blue" : "0x70",
+          "green" : "0x44",
+          "red" : "0x22"
         }
       },
       "idiom" : "universal"

--- a/Diverology/Diverology/Resource/Extension/SwiftUI+/EdgeInsets+.swift
+++ b/Diverology/Diverology/Resource/Extension/SwiftUI+/EdgeInsets+.swift
@@ -1,0 +1,23 @@
+//
+//  EdgeInsets+.swift
+//  Diverology
+//
+//  Created by jeongminji on 4/16/25.
+//
+
+
+import SwiftUI
+
+extension EdgeInsets {
+    init(horizontal: CGFloat = 0, vertical: CGFloat = 0) {
+        self.init(top: vertical, leading: horizontal, bottom: vertical, trailing: horizontal)
+    }
+    
+    init(horizontal: CGFloat = 0, top: CGFloat = 0, bottom: CGFloat = 0) {
+        self = EdgeInsets(top: top, leading: horizontal, bottom: bottom, trailing: horizontal)
+    }
+    
+    init(vertical: CGFloat = 0, leading: CGFloat = 0, trailing: CGFloat = 0) {
+        self = EdgeInsets(top: vertical, leading: leading, bottom: vertical, trailing: trailing)
+    }
+}

--- a/Diverology/Diverology/Resource/UIComponents/CustomNavigationBar.swift
+++ b/Diverology/Diverology/Resource/UIComponents/CustomNavigationBar.swift
@@ -1,0 +1,91 @@
+//
+//  CustomNavigationBar.swift
+//  Diverology
+//
+//  Created by jeongminji on 4/16/25.
+//
+
+import SwiftUI
+
+struct CustomNavigationBar: View {
+    @Environment(\.presentationMode) var presentationMode
+    
+    var showBackButton: Bool = true
+    var showLogo: Bool = false
+    var rightItem: AnyView? = nil
+
+    var body: some View {
+        HStack {
+            if showBackButton {
+                Button{
+                    presentationMode.wrappedValue.dismiss()
+                } label:{
+                    Image(systemName: "chevron.left")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 20, height: 20)
+                        .foregroundColor(.blue800)
+                }
+            }
+            
+            if showLogo {
+                Text("Diverology")
+                    .font(.newYork(size: 25))
+                    .foregroundColor(.semanticBlue600)
+            }
+            
+            Spacer()
+            
+            if let rightItem = rightItem {
+                rightItem
+            }
+        }
+        .frame(height: 44)
+        .padding(.horizontal, 20)
+        .background(.clear)
+    }
+}
+
+
+#Preview {
+    CustomNavigationBar(
+        showBackButton: true,
+        rightItem: AnyView(
+            Button{
+                print("삭제 눌림")
+            } label: {
+                Text("삭제")
+                    .font(.pretendard(.bold, size: 20))
+                    .foregroundColor(.blue800)
+            }
+        )
+    )
+    .background(.blue400)
+    
+    CustomNavigationBar(
+        showBackButton: false,
+        rightItem: AnyView(
+            Button(
+                action: { print("수정 눌림") }
+            ) {
+                Image(systemName: "square.and.pencil")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 23, height: 20)
+                    .foregroundColor(.blue800)
+            }
+        )
+    )
+    .background(.blue400)
+    
+    CustomNavigationBar(
+        showBackButton: true
+    )
+    .background(.blue400)
+    
+    CustomNavigationBar(
+        showBackButton: false,
+        showLogo: true
+    )
+    .background(.blue400)
+}

--- a/Diverology/Diverology/Resource/UIComponents/CustomTabBar.swift
+++ b/Diverology/Diverology/Resource/UIComponents/CustomTabBar.swift
@@ -23,32 +23,26 @@ struct CustomTabBar: View {
     ]
     
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.white)
-                .opacity(0.3)
-                
-            HStack {
-                ForEach(tabs, id: \.0) { tab, imageName, label, imageSize in
-                    TabButton(
-                        isSelected: selectedTab == tab,
-                        imageName: imageName,
-                        label: label,
-                        imageSize: imageSize
-                    ) {
-                        withAnimation {
-                            selectedTab = tab
-                        }
-                    }
-                    if tab != tabs.last?.0 {
-                        Spacer()
+        HStack {
+            ForEach(tabs, id: \.0) { tab, imageName, label, imageSize in
+                TabButton(
+                    isSelected: selectedTab == tab,
+                    imageName: imageName,
+                    label: label,
+                    imageSize: imageSize
+                ) {
+                    withAnimation {
+                        selectedTab = tab
                     }
                 }
+                if tab != tabs.last?.0 {
+                    Spacer()
+                }
             }
-            .padding(.bottom, 30)
-            .padding(.horizontal, 53)
         }
         .frame(height: 87)
+        .padding(.init(horizontal: 53, bottom: 30))
+        .background(.white.opacity(0.3))
     }
 }
 
@@ -76,4 +70,13 @@ struct TabButton: View {
             .frame(width: 52, height: 38)
         }
     }
+}
+
+#Preview {
+    @Previewable
+    @State var selectedTab: BottomTab = .home
+    
+    CustomTabBar(
+        selectedTab: $selectedTab
+    )
 }


### PR DESCRIPTION
<!-- 

Title: [prefix] #이슈번호 - 이슈 내용

Prefix

[Add]: 기능과 무관한 코드 추가 (라이브러리 추가, 유틸리티 함수 추가 등)
[Chore]: 그 이외의 잡일/ 버전 코드 수정, 패키지 구조 변경, 파일 이동, 파일이름 변경
[Comment]: 필요한 주석 추가 및 변경
[Del]: 쓸모없는 코드, 주석 삭제
[Design]: 뷰 구현 (UI 관련 코드 추가 및 수정)
[Docs]: README나 WIKI 등의 문서 개정
[Feat]: 새로운 기능 구현
[Fix]: 버그, 오류 해결, 코드 수정
[Merge]: 머지
[Refactor]: 전면 수정이 있을 때 사용합니다
[Remove]: 파일 삭제
[Setting]: 프로젝트 세팅 및 전반적 기능
[Test]: 테스트 코드

-->

# 🌊 Issue
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
<!-- 종료키워드 close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved -->
close #6 

<br/>

# 🐬 PR Point
<!-- 주요 작업 내용이나 리뷰어에게 알릴 메세지, 주요 코드를 써주세요 -->

CustomNavigationBar에서는 아래 애들을 파라미터로 받습니다!
showBackButton의 값에 따라 왼쪽에 뒤로가기 버튼을 둘지 말지 결정하고, 로고도 showLogo을 통해 보일지 말지 결정 합니다!
오른쪽에는 다양한 형태의 버튼이 올 수 있도록 rightItem은 AnyView로 받도록 하였습니다. 
```swift
    var showBackButton: Bool = true
    var showLogo: Bool = false
    var rightItem: AnyView? = nil
```

탭바도 조금 수정했습니다!
기존에는  탭바의 텍스트와 이미지 투명도는 그대로 두고 배경만 살짝 투명하게 하고 싶어서, ZStack을 사용하여 흰색 사각형을 맨 밑에 깔아주는 식으로 사용했습니다.

깔아준 사각형 없애고 간단한 방식으로 수정했습니다. 

```swift
background(.white.opacity(0.3))
```

<br/>



# 📷 ScreenShot
<!-- 큰 이미지, png 짜를때 재사용하세요.
<img src = "이미지_주소" width = "50%" height = "50%">
-->

<img width="314" alt="스크린샷 2025-04-16 오후 8 02 24" src="https://github.com/user-attachments/assets/5fa5a54e-9189-4bb1-a59d-d5930c5223ec" />

<br/>
